### PR TITLE
🔦 Highlight Base85 efficiency for UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Efficiency ratings are averaged over long inputs. Higher is better.
 		<tr>
 			<td>Base85</td>
 			<td>everywhere</td>
-			<td style="text-align: right;">80%</td>
+			<td style="text-align: right;"><strong>80%</strong></td>
 			<td style="text-align: right;">40%</td>
 			<td style="text-align: right;">20%</td>
 		</tr>


### PR DESCRIPTION
Base85 has the highest efficiency in the UTF-8 column, so why not to highlight it? ^_^