### PR TITLE
Add online version

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ MIT
 
 * [`base65536-stream`](https://github.com/qntm/base65536-stream) - streaming implementation
 * [`base65536-cli`](https://github.com/qntm/base65536-cli) - command-line tool
+* [`base65536-online`](https://github.com/lixiang810/base65536-online) - use base65536 to encode / decode text online
 
 ## In other languages
 


### PR DESCRIPTION
Base65536 is nice, but there is no pure front-end online converter yet. Therefore, I wrote one in React. The [demo](https://base65536.penclub.club/) is here.